### PR TITLE
Fix validate workflow

### DIFF
--- a/src/bjj_vqa/task.py
+++ b/src/bjj_vqa/task.py
@@ -13,14 +13,16 @@ def record_to_sample(record: dict) -> Sample:
     """Convert a JSON record to an inspect-ai Sample with multimodal input."""
     full_image_path = str(DATA_DIR / record["image"])
 
-    input_content = [
-        ContentImage(image=full_image_path),
-        ContentText(text=record["question"]),
-    ]
-
     return Sample(
         id=record["id"],
-        input=[ChatMessageUser(content=input_content)],
+        input=[
+            ChatMessageUser(
+                content=[
+                    ContentImage(image=full_image_path),
+                    ContentText(text=record["question"]),
+                ],
+            ),
+        ],
         choices=record["choices"],
         target=record["answer"],
         metadata={


### PR DESCRIPTION
Resolves issue #10 - ty check type inference error in task.py.

Inline the content list in ChatMessageUser to fix ty's type inference. The previous approach created a variable input_content which ty inferred as a narrower type than the full union expected by inspect-ai.