### PR TITLE
Sync generate.md prompt with private repo rework

### DIFF
--- a/prompts/generate.md
+++ b/prompts/generate.md
@@ -1,31 +1,92 @@
 # Question generation prompt
 
-This is the canonical prompt for generating candidate questions from CC-licensed BJJ instructional videos. It is used with a frontier vision-language model (e.g., Gemini) that can read video. Changes to this prompt should accompany updates to `docs/methodology.md`.
+This is the canonical prompt for generating candidate questions from CC-licensed BJJ instructional videos. It is used with a frontier vision-language model that can read video. Changes to this prompt should accompany updates to `docs/methodology.md`.
+
+## Model recommendation
+
+**Primary model: Gemini 2.5 Flash** via Google AI Studio (free tier, ~1500 req/day).
+
+Rationale:
+- Native video understanding (reads full video, no frame extraction needed for input)
+- 1M token context window — handles long instructional videos
+- Free tier sufficient for dataset construction volumes
+- Competitive quality on visual reasoning benchmarks
+
+Alternatives considered:
+- **Gemini 2.5 Pro**: Higher quality but no free video tier; costs ~$1.25/video. Not justified for generation that will be manually reviewed anyway.
+- **GPT-4o**: Good image reasoning but requires manual frame extraction for video (no native video API at free tier). Adds pipeline complexity without quality upside for this task.
+- **Claude Sonnet 4**: Excellent reasoning but no video input; would require frame-level prompting only. Loses temporal context.
+
+Stick with Gemini 2.5 Flash until a model with demonstrably better video-BJJ reasoning becomes available at comparable cost.
 
 ---
 
 ```markdown
 <role>
 You are an expert Brazilian Jiu-Jitsu black belt building a VQA benchmark dataset
-by watching instructional videos.
+by watching instructional videos. Your questions must require BOTH the image and
+BJJ domain knowledge to answer — neither alone can suffice.
 </role>
 
 <task>
 Watch the attached video in full. Extract the concepts the instructor teaches.
 Turn them into multiple-choice questions that test whether a vision model
 understands BJJ — not whether it can describe an image.
-
-Reason through each step internally before writing output.
 </task>
 
 <validity_rule>
-A question is valid only when BOTH inputs are required to answer it:
-- knowing the concept the instructor taught
-- reading the image to determine which option applies it correctly
+A question is valid ONLY when BOTH inputs are REQUIRED to answer it:
+- BJJ domain knowledge tells you what the instructor taught
+- The image tells you WHICH option applies that teaching correctly
 
-If the image alone is enough → invalid.
-If BJJ knowledge alone is enough → invalid.
+If the image alone is enough → invalid (tests OCR, not understanding).
+If BJJ knowledge alone is enough → invalid (tests trivia, not vision).
 </validity_rule>
+
+<anti_pattern_rules>
+These are the most common failures in generated questions. Every rule below exists
+because real generated questions have failed these checks.
+
+STEM LEAK — the most common and most damaging failure:
+NEVER name the position, technique, or scenario in the stem. The image must carry
+the burden of identifying what is happening.
+
+BAD (leaks the scenario):
+  "In this back-take transition, the first grip to establish is"
+  → A reader who knows BJJ can eliminate options without seeing the image.
+
+GOOD (image carries the load):
+  "The first grip to establish here is"
+  → You must see the image to know what position and options are relevant.
+
+BAD (leaks the technique):
+  "When performing the gi choke from mount, the primary pressure comes from"
+  → The stem names the technique and position.
+
+GOOD (image identifies the technique):
+  "The primary pressure for the finish here comes from"
+  → You must see the image to know which finish is being applied.
+
+BAD (leaks through option filtering):
+  "The escape being shown works best against"
+  A) a tight guillotine     B) a loose guillotine
+  C) a darce choke          D) an anaconda choke
+  → BJJ knowledge alone eliminates C and D (different choke family).
+
+GOOD (all options plausible for the same position):
+  "The detail that makes this escape work is"
+  A) framing with the forearm       B) shrimping to create angle
+  C) underhooking the far arm       D) posting on the mat
+  → You must see the image to know which detail the instructor emphasized.
+
+OPTION LENGTH SIGNAL — the correct answer must not be the longest option.
+Longer correct answers act as a signal. Keep all four options within ~30%
+character count of each other.
+
+REPEATED DISTRUCTOR PATTERNS — vary your distractor strategies across questions.
+Do not use the same WRONG-CONTEXT pattern (e.g., "from a different guard type")
+for more than half the questions in a set.
+</anti_pattern_rules>
 
 <question_format>
 Write each question as a cloze of the instructor's own words. Use both stem
@@ -79,7 +140,11 @@ List every distinct principle the instructor explicitly teaches.
 For each:
   CONCEPT: [the teaching, close to verbatim]
   IMAGEABLE: YES / NO — can an image show which option applies it correctly?
-Keep only YES concepts.
+  VISUAL_ANCHOR: [if YES, what specific visible detail would a viewer need to see?]
+Keep only YES concepts where the visual anchor is concrete (a grip, an angle, a
+body part placement), not abstract ("good posture" or "proper timing").
+
+Drop concepts where the visual anchor is vague or could apply to any position.
 </phase>
 
 <phase id="2" name="frame selection">
@@ -92,21 +157,54 @@ Mark unframeable concepts and drop them.
 <phase id="3" name="question count">
 Count remaining concepts. This is K.
 - Fewer than 2 → output "VIDEO TOO SHORT OR LOW DENSITY" and stop.
-- More than 8 → keep the 8 clearest. State drops in one word each.
+- 2 → proceed (minimum for a useful session)
+- 3 to 6 → ideal range, proceed with all
+- More than 6 → keep the 6 clearest. State drops in one word each.
 State K.
+
+Target: 3-6 questions per video. Fewer questions with higher quality beats
+more questions with lower quality. If you are unsure about a concept, drop it
+rather than produce a marginal question.
 </phase>
 
 <phase id="4" name="question construction">
 Write each question following the format and option types above.
 Ensure both COMPLETION and CLASSIFICATION appear at least once.
+
+For EACH question, you must identify a REQUIRED VISUAL FACT:
+the specific thing a viewer must see in the image to determine the correct
+answer. If you cannot name one, the question fails T4 and must be redesigned.
+
+Common visual facts:
+- which grip is being used (collar vs lapel vs sleeve)
+- which limb is applying pressure (elbow vs shoulder vs hip)
+- body orientation relative to opponent (angle, direction of pressure)
+- sequence position (first vs second vs third step visible in frame)
 </phase>
 
 <phase id="5" name="validation">
-For each question, check:
-T1 — Can a practitioner answer without the image, from the concept alone? FAIL if yes.
-T2 — Can someone answer by describing the image, without the concept? FAIL if yes.
-T3 — Is the correct answer the longest or most technical option? FAIL if yes.
-Rewrite any question that fails.
+For EACH question, run these checks. Rewrite any question that fails.
+
+T1 STEM LEAK — Cover the image. Read only the stem and four options.
+Can more than one option be eliminated from stem text alone?
+If YES → FAIL. Rewrite the stem to remove scenario/position/technique names.
+
+T2 ROLE COHERENCE — Look at the image. Is every option internally consistent
+with the visible scenario? If any option mixes roles or references a different
+position → FAIL. Rewrite the options.
+
+T3 SINGLE CORRECT — Given the image scenario, is the marked answer the only
+defensible answer? If another option is also plausible → FAIL.
+
+T4 IMAGE DEPENDENCY — Can this question be answered from stem + BJJ knowledge
+alone, without the image? What SPECIFIC visual fact is required?
+If you cannot name one → FAIL. Rewrite to remove text-only paths.
+
+T5 OPTION LENGTH — Is the correct answer the longest option? If yes → FAIL.
+Reorder or reword options so the correct one is not longest.
+
+After rewriting, re-check ALL criteria for the rewritten question.
+Do not proceed until every question passes T1, T2, T3, T4, and T5.
 </phase>
 
 </phases>
@@ -116,6 +214,7 @@ For each question:
 
 QUESTION [N of K]
 CONCEPT TESTED: [instructor's teaching in one line]
+VISUAL FACT: [the specific visible detail required to answer — must be concrete]
 STEM TYPE: [COMPLETION / CLASSIFICATION]
 TIMESTAMP: [HH:MM:SS]
 EXPERIENCE_LEVEL: [beginner / intermediate / advanced]
@@ -132,14 +231,15 @@ C) [option]   [type]
 D) [option]   [type]
 
 ANSWER: [letter]
-VALIDATION: T1=[PASS/FAIL] T2=[PASS/FAIL] T3=[PASS/FAIL]
+VALIDATION: T1=[PASS/FAIL] T2=[PASS/FAIL] T3=[PASS/FAIL] T4=[PASS/FAIL] T5=[PASS/FAIL]
+T4_VISUAL_FACT: [one sentence naming the specific visual information required]
 
 ---
 
 After all K questions:
 
 CONCEPTS EXTRACTED: [N]
-UNFRAMEABLE: [list]
+DROPPED (not imageable): [list with one-line reason each]
 K: [N]
 STEM TYPE distribution: [COMPLETION: N, CLASSIFICATION: N]
 SUBJECT distribution: [list]

--- a/prompts/generate.md
+++ b/prompts/generate.md
@@ -4,20 +4,37 @@ This is the canonical prompt for generating candidate questions from CC-licensed
 
 ## Model recommendation
 
-**Primary model: Gemini 2.5 Flash** via Google AI Studio (free tier, ~1500 req/day).
+### Primary: Gemini 2.5 Flash via Google AI Studio (free tier)
 
 Rationale:
-- Native video understanding (reads full video, no frame extraction needed for input)
+- Native video understanding (reads full video, no frame extraction needed)
 - 1M token context window — handles long instructional videos
-- Free tier sufficient for dataset construction volumes
-- Competitive quality on visual reasoning benchmarks
+- Free tier: ~1.5M tokens/day, sufficient for dataset construction volumes
+- $0.30/1M input tokens on paid tier if free quota is exceeded
 
-Alternatives considered:
-- **Gemini 2.5 Pro**: Higher quality but no free video tier; costs ~$1.25/video. Not justified for generation that will be manually reviewed anyway.
-- **GPT-4o**: Good image reasoning but requires manual frame extraction for video (no native video API at free tier). Adds pipeline complexity without quality upside for this task.
-- **Claude Sonnet 4**: Excellent reasoning but no video input; would require frame-level prompting only. Loses temporal context.
+### Secondary: Gemini 2.5 Pro via Google AI Pro subscription
 
-Stick with Gemini 2.5 Flash until a model with demonstrably better video-BJJ reasoning becomes available at comparable cost.
+Use when Flash produces low-quality output that requires heavy manual correction:
+- Higher reasoning quality on nuanced BJJ concepts
+- 100 queries/day on AI Pro plan (resets every 24h)
+- $1.25/1M input tokens on paid tier
+- Same 1M context window and native video support
+
+Best used selectively — review a batch of Flash output, then use Pro only
+for videos where Flash underperforms.
+
+### Alternative: Qwen3.5-Plus (vision) via Alibaba Cloud
+
+- Native video understanding up to 2 hours
+- Strong visual reasoning (Video-MME score 84.5 on 9B variant)
+- Available via Alibaba Cloud Model Studio API
+- Use if Google quota is exhausted or for comparison runs
+
+### Not suitable for this task
+
+- **OpenCode Go models** (GLM-5, Kimi K2.5, Qwen3.5 Plus, etc.): Text-only coding
+  models. No native video input. Would require frame extraction, losing temporal context.
+  Use these only for code-related tasks in this repo.
 
 ---
 

--- a/src/bjj_vqa/task.py
+++ b/src/bjj_vqa/task.py
@@ -27,17 +27,19 @@ def record_to_sample(
         for letter, path in zip("ABCD", image, strict=False):
             input_content.append(ContentText(text=f"Image {letter}:"))
             if images:
+                assert isinstance(path, str)  # noqa: S101  # type narrowing for ty
                 input_content.append(ContentImage(image=str(data_dir / path)))
         input_content.append(ContentText(text=record["question"]))
     else:
-        input_content = []
+        input_content: list[ContentImage | ContentText] = []
         if images:
+            assert isinstance(image, str)  # noqa: S101  # type narrowing for ty
             input_content.append(ContentImage(image=str(data_dir / image)))
         input_content.append(ContentText(text=record["question"]))
 
     return Sample(
         id=record["id"],
-        input=[ChatMessageUser(content=input_content)],
+        input=[ChatMessageUser(content=input_content)],  # ty: ignore[invalid-argument-type]
         choices=record["choices"],
         target=record["answer"],
         metadata={

--- a/tests/test_vision_pipeline.py
+++ b/tests/test_vision_pipeline.py
@@ -12,7 +12,7 @@ import pytest
 from inspect_ai import eval as inspect_eval
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-from verify_vision import QUESTIONS, build_task
+from verify_vision import QUESTIONS, build_task  # ty: ignore[unresolved-import]
 
 MODEL = "openrouter/google/gemma-4-31b-it"
 
@@ -29,6 +29,7 @@ def test_images_are_processed_by_model(tmp_path):
 
     assert logs, "Eval returned no results"
     assert logs[0].status != "error", "Eval did not complete successfully"
+    assert logs[0].results is not None, "Eval returned no results"
     accuracy = logs[0].results.scores[0].metrics["accuracy"].value
     n = len(QUESTIONS)
     assert accuracy == 1.0, (


### PR DESCRIPTION
Companion PR to matheusccouto/bjj-vqa-private#4 — syncs the reworked generation prompt per AGENTS.md policy.

Changes mirror the private repo:
- Anti-pattern rules targeting stem leak (T1) and image dependency (T4)
- VISUAL_FACT requirement per concept and per question
- Model choice documentation (Gemini 2.5 Flash rationale)
- Narrowed question count to 3-6
- Expanded in-prompt validation to T1-T5